### PR TITLE
Update colyseus to v0.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@colyseus/arena": "^0.14.22",
-        "@colyseus/monitor": "^0.14.20",
+        "@colyseus/monitor": "^0.15.1",
+        "@colyseus/tools": "^0.15.2",
         "@mojotech/json-type-validation": "^3.1.0",
         "@types/clone": "^2.1.1",
         "clone": "^2.1.2",
-        "colyseus": "^0.14.20",
+        "colyseus": "^0.15.2",
         "cors": "^2.8.5",
         "dfg-messages": "github:yncat/dfg-messages#master",
         "dfg-simulator": "^1.3.5",
@@ -26,8 +26,8 @@
         "typescript": "^3.4.5"
       },
       "devDependencies": {
-        "@colyseus/loadtest": "^0.14.4",
-        "@colyseus/testing": "^0.14.21",
+        "@colyseus/loadtest": "^0.15.2",
+        "@colyseus/testing": "^0.15.2",
         "@types/chai": "^4.2.21",
         "@types/chai-as-promised": "^7.1.4",
         "@types/cors": "^2.8.6",
@@ -662,152 +662,156 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "peer": true
     },
-    "node_modules/@colyseus/arena": {
-      "version": "0.14.22",
-      "resolved": "https://registry.npmjs.org/@colyseus/arena/-/arena-0.14.22.tgz",
-      "integrity": "sha512-PBzg5eQYLZG2VHvOiZLKmhYQwyJYTv5DNgAgfAoKHGXLHeKCqfBLzu0RC4Q3X/2GCMSLqaWu5luZVLsbXz0SzA==",
-      "dependencies": {
-        "@colyseus/core": "0.14.20",
-        "cors": "^2.8.5",
-        "dotenv": "^8.2.0",
-        "express": "^4.16.2"
-      }
-    },
     "node_modules/@colyseus/core": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/@colyseus/core/-/core-0.14.20.tgz",
-      "integrity": "sha512-d+c3vI1lDGGOtbhZIZxM4DHdSTMflFwy4V/cm/Fy1eqMG+yx1dpu8KmZI1BX+C1tMq4oGQ6xAFPCwA8snSbo4A==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@colyseus/core/-/core-0.15.6.tgz",
+      "integrity": "sha512-GfinNB0KTV5vSkwPr6bIUHi09D1mjN7IFPVrbEE5Haca0DJQKjhtftOdxwvNQSngwVQOOD/5lYKn10AS0J9p0g==",
       "dependencies": {
-        "@colyseus/schema": "^1.0.15",
+        "@colyseus/greeting-banner": "^2.0.0",
+        "@colyseus/schema": "^2.0.4",
         "@gamestdio/timer": "^1.3.0",
         "@types/redis": "^2.8.12",
-        "debug": "^4.0.1",
+        "debug": "^4.3.4",
         "internal-ip": "^4.3.0",
-        "nanoid": "^2.0.0",
-        "notepack.io": "^2.2.0"
+        "msgpackr": "^1.9.1",
+        "nanoid": "^2.0.0"
       },
       "engines": {
-        "node": ">= 12.x"
+        "node": ">= 14.x"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/endel"
       }
+    },
+    "node_modules/@colyseus/core/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@colyseus/greeting-banner": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@colyseus/greeting-banner/-/greeting-banner-2.0.2.tgz",
+      "integrity": "sha512-BjcOIiVUyPecK5U93TIi6O0QtrejGajitH1zRqHu6ytBhzKvR40GpKLuKfsUXrUWNEY7ytKRuEQLF9akBYRqMw=="
     },
     "node_modules/@colyseus/loadtest": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@colyseus/loadtest/-/loadtest-0.14.4.tgz",
-      "integrity": "sha512-Y+E86INsy47vNg9X/Vyx6u7zQPzMFYGa2KkAYnTXM00L4GDrWqg40jQY4MBX0XBE3zWKm9W3+N0cgMaUZlQjKQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@colyseus/loadtest/-/loadtest-0.15.2.tgz",
+      "integrity": "sha512-HO+60VLgmls0NC9ALk9BPB4M+mAM/IlD30xgV+S/78mv0V9GBPI4Ycx6W6Mt3jqi8oMBAh5JbWY9Iy386A4dnQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^10.12.18",
         "blessed": "^0.1.81",
-        "colyseus.js": "^0.14.8",
-        "minimist": "^1.2.0",
-        "ts-node": "^7.0.1",
-        "typescript": "^3.2.4",
-        "ws": "^6.1.4"
+        "colyseus.js": "^0.15.0",
+        "minimist": "^1.2.5",
+        "typescript": ">=4.3.5",
+        "ws": "^7.4.5"
       },
       "bin": {
-        "colyseus-loadtest": "bin/colyseus-loadtest"
+        "colyseus-loadtest": "bin.js"
       }
     },
-    "node_modules/@colyseus/loadtest/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true
-    },
-    "node_modules/@colyseus/loadtest/node_modules/ts-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+    "node_modules/@colyseus/loadtest/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
-      "dependencies": {
-        "arrify": "^1.0.0",
-        "buffer-from": "^1.1.0",
-        "diff": "^3.1.0",
-        "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^2.0.0"
-      },
       "bin": {
-        "ts-node": "dist/bin.js"
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/@colyseus/loadtest/node_modules/ws": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
-      "dev": true,
-      "dependencies": {
-        "async-limiter": "~1.0.0"
-      }
-    },
-    "node_modules/@colyseus/mongoose-driver": {
-      "version": "0.14.22",
-      "resolved": "https://registry.npmjs.org/@colyseus/mongoose-driver/-/mongoose-driver-0.14.22.tgz",
-      "integrity": "sha512-Bqg+1XGHo4t3UUqBxSCDuvxzuuDBObxOWVBH0GjdFmXWzJgrkMgkDFH8YXjo9h/sXaPRJNzJRlXMCV1txbYadw==",
-      "dependencies": {
-        "@colyseus/core": "^0.14.20",
-        "mongoose": "^5.11.3"
+        "node": ">=14.17"
       }
     },
     "node_modules/@colyseus/monitor": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/@colyseus/monitor/-/monitor-0.14.20.tgz",
-      "integrity": "sha512-D95I6f04oMOizjY24pWB3LSC7OdJFGz2K7zY8bPapLPtES+BCzPLxPI36ohAmIlMdDmsG7DRjpad77W9cUM5tg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@colyseus/monitor/-/monitor-0.15.1.tgz",
+      "integrity": "sha512-/ZT8lCjiQ82sNqmqLTUCGgaOiNeThMf8/d3srQXYg2gJqsct5xVFE9s0uFmtdObASMqs3aqQsicay/06we43Cg==",
       "dependencies": {
         "express": "^4.16.2",
         "node-os-utils": "^1.2.0",
         "superagent": "^3.8.2"
-      },
-      "peerDependencies": {
-        "@colyseus/core": "^0.14.17-alpha.5"
+      }
+    },
+    "node_modules/@colyseus/redis-driver": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@colyseus/redis-driver/-/redis-driver-0.15.3.tgz",
+      "integrity": "sha512-mvOxgLpx1Nrb9hmxuMHRAKJ2MkE/37KHPYWxARKIq0/lxyO1IeZOWnszbJbd8iWN9RBsQgB6jvhrTjr08tFs/w==",
+      "dependencies": {
+        "@colyseus/core": "^0.15.0",
+        "ioredis": "^5.3.2"
       }
     },
     "node_modules/@colyseus/redis-presence": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/@colyseus/redis-presence/-/redis-presence-0.14.20.tgz",
-      "integrity": "sha512-ZxpY9ji/tGYT4ms/4q5w7tjUfqekCDnpZ8J+XuXVpZN02iD6cd/RpCwIyaEsRUVpkcRZw9jxX8hSQ3L5aG/3VA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@colyseus/redis-presence/-/redis-presence-0.15.2.tgz",
+      "integrity": "sha512-uq52c+fmJCNdBrbVtulhAKEa2tEiLB6y4V7ZOBC7A1ddT2Gz8JUQpCN7dvA1nmQQhiK22xe7RdGF6PDtJeL5Hw==",
       "dependencies": {
-        "@colyseus/core": "^0.14.20",
-        "redis": "^2.8.0"
+        "@colyseus/core": "^0.15.0",
+        "ioredis": "^5.3.2"
       }
     },
     "node_modules/@colyseus/schema": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/@colyseus/schema/-/schema-1.0.26.tgz",
-      "integrity": "sha512-YbTTO3L7lcpxK0Bw64AwU9l0bJwaobzVn/PQQ+nc3uqZvusw7V0HBNfcAYHXc5TcDp4BuZ6c0fIttj1bx9IuGQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@colyseus/schema/-/schema-2.0.14.tgz",
+      "integrity": "sha512-ugbvrAxbdTufMS2TVjCpPRAx7enb+gv4CbcsszAgymaYzonlYUd+J8TYPzhIqOyRS7c41KZADToq1tMTQq3GFw==",
       "bin": {
         "schema-codegen": "bin/schema-codegen"
       }
     },
     "node_modules/@colyseus/testing": {
-      "version": "0.14.21",
-      "resolved": "https://registry.npmjs.org/@colyseus/testing/-/testing-0.14.21.tgz",
-      "integrity": "sha512-E38baXs5ljmSt4pfGi+hg5LXzez+x50M5qZAiXSWFpXs0cItKEJHGMlI2tdt7kQJIEAHkqorz+iNcJovg5pdMg==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@colyseus/testing/-/testing-0.15.2.tgz",
+      "integrity": "sha512-lL7a7ziGvuRwvdh08tHer8ciJ2VcB9doNX0YCaLrxQDsRa2XkP86+Gk709lyh7GsxIQyAnKoNr18FmFGLoI4Eg==",
       "dev": true,
       "dependencies": {
-        "@colyseus/arena": "^0.14.17",
-        "@colyseus/core": "^0.14.17",
-        "colyseus.js": "^0.14.13",
+        "@colyseus/core": "^0.15.0",
+        "@colyseus/tools": "^0.15.0",
+        "colyseus.js": "^0.15.0",
         "httpie": "^2.0.0-next.13"
       },
       "engines": {
         "node": ">= 14.x"
       }
     },
-    "node_modules/@colyseus/ws-transport": {
-      "version": "0.14.21",
-      "resolved": "https://registry.npmjs.org/@colyseus/ws-transport/-/ws-transport-0.14.21.tgz",
-      "integrity": "sha512-lQXqwp5MOAdFLOn6UCuSZh0hqFMRYjAkW0B0qCNqKjaGjhsupF+z6hdEX5erJpLmdMiL4wxipvYaYoG2KjxfwA==",
+    "node_modules/@colyseus/tools": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@colyseus/tools/-/tools-0.15.18.tgz",
+      "integrity": "sha512-tgDA11Zx/slfl+UMPGn5q28/aQ8Nw461M1O2obgAxc/bb/iw6TxTSdbSHBpNpI2CEt/AKVLbL7XtEGBCUvxQJQ==",
       "dependencies": {
-        "@colyseus/core": "^0.14.20",
-        "@colyseus/schema": "^1.0.15",
+        "@colyseus/core": "^0.15.0",
+        "@colyseus/ws-transport": "^0.15.0",
+        "cors": "^2.8.5",
+        "dotenv": "^8.2.0",
+        "express": "^4.16.2",
+        "node-os-utils": "^1.3.7"
+      },
+      "bin": {
+        "colyseus-post-deploy": "post-deploy.js",
+        "colyseus-system-boot": "system-boot.js"
+      }
+    },
+    "node_modules/@colyseus/ws-transport": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@colyseus/ws-transport/-/ws-transport-0.15.1.tgz",
+      "integrity": "sha512-9QWb0OeZHDF2+PVIJ9LY0GriItnOatJCgmAG31ygfeEn1+ApkG1Ds/+cU7aBnYE2SGGWF4sKGAM3XUvScCRq4w==",
+      "dependencies": {
+        "@colyseus/core": "^0.15.0",
         "@types/ws": "^7.4.4",
         "ws": "^7.4.5"
+      },
+      "peerDependencies": {
+        "@colyseus/schema": ">=1.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -879,7 +883,7 @@
     "node_modules/@gamestdio/clock": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@gamestdio/clock/-/clock-1.1.9.tgz",
-      "integrity": "sha1-d+wMAROR+7/ctPMhEkKVNv2GgMs="
+      "integrity": "sha512-O+PG3aRRytgX2BhAPMIhbM2ftq1Q8G4xUrYjEWYM6EmpoKn8oY4lXENGhpgfww6mQxHPbjfWyIAR6Xj3y1+avw=="
     },
     "node_modules/@gamestdio/timer": {
       "version": "1.3.2",
@@ -908,6 +912,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1478,6 +1487,78 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1632,14 +1713,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/bson": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "4.2.21",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
@@ -1749,15 +1822,6 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
-    "node_modules/@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "dependencies": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz",
@@ -1806,9 +1870,9 @@
       "dev": true
     },
     "node_modules/@types/redis": {
-      "version": "2.8.31",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.31.tgz",
-      "integrity": "sha512-daWrrTDYaa5iSDFbgzZ9gOOzyp2AJmYK59OlG/2KGBgYWF3lfs8GDKm1c//tik5Uc93hDD36O+qLPvzDolChbA==",
+      "version": "2.8.32",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
+      "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2243,15 +2307,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -2269,12 +2324,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2386,15 +2435,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "node_modules/blessed": {
       "version": "0.1.81",
       "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
@@ -2406,11 +2446,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "node_modules/body-parser": {
       "version": "1.19.2",
@@ -2512,14 +2547,6 @@
       "peer": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
-      "engines": {
-        "node": ">=0.6.19"
       }
     },
     "node_modules/buffer-from": {
@@ -2699,6 +2726,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2732,33 +2767,56 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colyseus": {
-      "version": "0.14.23",
-      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.14.23.tgz",
-      "integrity": "sha512-y2F0vmOx+k8nG2KGcKMeDNjamYNYA+x+E0dVqqWw7lD6g2PhuX8/hkGRrWagJqbFiYTIMfZfa+zN9DinAMCshg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.15.7.tgz",
+      "integrity": "sha512-ot3b/dDrox3GO1h+cAFis0S86EVrqp+GwF2ovP5yQARVhnEE89xtJPZ/DltzLzZrhCIc0XhkP35oh2SSu+d85Q==",
       "dependencies": {
-        "@colyseus/core": "^0.14.20",
-        "@colyseus/mongoose-driver": "^0.14.21",
-        "@colyseus/redis-presence": "^0.14.20",
-        "@colyseus/ws-transport": "^0.14.21"
+        "@colyseus/core": "^0.15.6",
+        "@colyseus/redis-driver": "^0.15.3",
+        "@colyseus/redis-presence": "^0.15.2",
+        "@colyseus/ws-transport": "^0.15.1"
       },
       "engines": {
         "node": ">= 14.x"
       }
     },
     "node_modules/colyseus.js": {
-      "version": "0.14.13",
-      "resolved": "https://registry.npmjs.org/colyseus.js/-/colyseus.js-0.14.13.tgz",
-      "integrity": "sha512-2z1jgOfozQ02gLG5RtTHpk9VZur2b7U4KI9NNldjOZmfc2DZeKejdcKchBTwiDcSwwJQQ4SSOfVUhOcBMILDqA==",
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/colyseus.js/-/colyseus.js-0.15.13.tgz",
+      "integrity": "sha512-MG6S3Zt0SZtALRKoeF/wfvkobMvHrNldJsbtrz+QQ4GSGzE+IdAx/RxkzzT5+GIqAq2W1dYyAjex/OS49bTV8g==",
       "dev": true,
       "dependencies": {
-        "@colyseus/schema": "^1.0.22",
+        "@colyseus/schema": "^2.0.4",
         "httpie": "^2.0.0-next.13",
-        "nanoevents": "^5.1.12",
-        "notepack.io": "^2.1.3",
-        "tslib": "^2.1.0"
+        "tslib": "^2.1.0",
+        "ws": "^8.13.0"
       },
       "engines": {
         "node": ">= 12.x"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/endel"
+      }
+    },
+    "node_modules/colyseus.js/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/combined-stream": {
@@ -3072,9 +3130,9 @@
       }
     },
     "node_modules/denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
       "engines": {
         "node": ">=0.10"
       }
@@ -3227,15 +3285,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -3297,11 +3346,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "node_modules/dynamic-dedupe": {
       "version": "0.3.0",
@@ -4478,10 +4522,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
       "engines": {
         "node": ">=4"
       }
@@ -4584,7 +4667,7 @@
     "node_modules/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5832,11 +5915,6 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
     },
-    "node_modules/kareem": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5901,10 +5979,20 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -5995,12 +6083,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/memory-pager": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -6096,18 +6178,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
     },
     "node_modules/mocha": {
       "version": "9.2.2",
@@ -6215,158 +6285,38 @@
         "node": ">=10"
       }
     },
-    "node_modules/mongodb": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.4.tgz",
-      "integrity": "sha512-K5q8aBqEXMwWdVNh94UQTwZ6BejVbFhh1uB6c5FKtPE9eUMZPUO3sRZdgIEcHSrAWmxzpG/FeODDKL388sqRmw==",
-      "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "optionalDependencies": {
-        "saslprep": "^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws4": {
-          "optional": true
-        },
-        "bson-ext": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "mongodb-extjson": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongodb/node_modules/optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "dependencies": {
-        "require-at": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mongoose": {
-      "version": "5.13.20",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.20.tgz",
-      "integrity": "sha512-TjGFa/XnJYt+wLmn8y9ssjyO2OhBMeEBtOHb9iJM16EWu2Du6L1Q6zSiEK2ziyYQM8agb4tumNIQFzqbxId7MA==",
-      "dependencies": {
-        "@types/bson": "1.x || 4.0.x",
-        "@types/mongodb": "^3.5.27",
-        "bson": "^1.1.4",
-        "kareem": "2.3.2",
-        "mongodb": "3.7.4",
-        "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.8.4",
-        "mquery": "3.2.5",
-        "ms": "2.1.2",
-        "optional-require": "1.0.x",
-        "regexp-clone": "1.0.0",
-        "safe-buffer": "5.2.1",
-        "sift": "13.5.2",
-        "sliced": "1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mongoose"
-      }
-    },
-    "node_modules/mongoose-legacy-pluralize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
-      "peerDependencies": {
-        "mongoose": "*"
-      }
-    },
-    "node_modules/mongoose/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/mpath": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/mquery": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
-      "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
-      "dependencies": {
-        "bluebird": "3.5.1",
-        "debug": "3.1.0",
-        "regexp-clone": "^1.0.0",
-        "safe-buffer": "5.1.2",
-        "sliced": "1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/mquery/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/mquery/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/nanoevents": {
-      "version": "5.1.13",
-      "resolved": "https://registry.npmjs.org/nanoevents/-/nanoevents-5.1.13.tgz",
-      "integrity": "sha512-JFAeG9fp0QZnRoESHjkbVFbZ9BkOXkkagUVwZVo/pkSX+Fq1VKlY+5og/8X9CYc6C7vje/CV+bwJ5M2X0+IY9Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
+    "node_modules/msgpackr": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.7.tgz",
+      "integrity": "sha512-baUNaLvKQvVhzfWTNO07njwbZK1Lxjtb0P1JL6/EhXdLTHzR57/mZqqJC39TtQKvOmkJA4pcejS4dbk7BDgLLA==",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.0.7"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
       }
     },
     "node_modules/nanoid": {
@@ -6436,6 +6386,17 @@
         }
       }
     },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+      "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6443,9 +6404,9 @@
       "peer": true
     },
     "node_modules/node-os-utils": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/node-os-utils/-/node-os-utils-1.3.5.tgz",
-      "integrity": "sha512-bIJIlk+hA+7/ATnu3sQMtF697iw9T/JksDhKMe9uENG0OhzIG7hLM6fbcyu18bOuajlYWnSlj0IhDo2q7k0ebg=="
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/node-os-utils/-/node-os-utils-1.3.7.tgz",
+      "integrity": "sha512-fvnX9tZbR7WfCG5BAy3yO/nCLyjVWD6MghEq0z5FDfN+ZXpLWNITBdbifxQkQ25ebr16G0N7eRWJisOcMEHG3Q=="
     },
     "node_modules/node-releases": {
       "version": "2.0.6",
@@ -6495,15 +6456,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/notepack.io": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
-      "integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA=="
-    },
     "node_modules/npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
       "dependencies": {
         "path-key": "^2.0.0"
       },
@@ -6559,14 +6515,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optional-require": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -6587,7 +6535,7 @@
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "engines": {
         "node": ">=4"
       }
@@ -6694,7 +6642,7 @@
     "node_modules/path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "engines": {
         "node": ">=4"
       }
@@ -7025,36 +6973,24 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/redis": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
-      "dependencies": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
-      },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4"
       }
-    },
-    "node_modules/redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
     },
     "node_modules/redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4"
       }
-    },
-    "node_modules/regexp-clone": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -7066,14 +7002,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/require-directory": {
@@ -7204,18 +7132,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -7308,7 +7224,7 @@
     "node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -7319,15 +7235,10 @@
     "node_modules/shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sift": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.3",
@@ -7401,11 +7312,6 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/sliced": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7421,15 +7327,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/sparse-bitfield": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "optional": true,
-      "dependencies": {
-        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {
@@ -7457,6 +7354,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -7522,7 +7424,7 @@
     "node_modules/strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7926,9 +7828,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -8354,15 +8256,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/yocto-queue": {
@@ -8847,131 +8740,121 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "peer": true
     },
-    "@colyseus/arena": {
-      "version": "0.14.22",
-      "resolved": "https://registry.npmjs.org/@colyseus/arena/-/arena-0.14.22.tgz",
-      "integrity": "sha512-PBzg5eQYLZG2VHvOiZLKmhYQwyJYTv5DNgAgfAoKHGXLHeKCqfBLzu0RC4Q3X/2GCMSLqaWu5luZVLsbXz0SzA==",
-      "requires": {
-        "@colyseus/core": "0.14.20",
-        "cors": "^2.8.5",
-        "dotenv": "^8.2.0",
-        "express": "^4.16.2"
-      }
-    },
     "@colyseus/core": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/@colyseus/core/-/core-0.14.20.tgz",
-      "integrity": "sha512-d+c3vI1lDGGOtbhZIZxM4DHdSTMflFwy4V/cm/Fy1eqMG+yx1dpu8KmZI1BX+C1tMq4oGQ6xAFPCwA8snSbo4A==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@colyseus/core/-/core-0.15.6.tgz",
+      "integrity": "sha512-GfinNB0KTV5vSkwPr6bIUHi09D1mjN7IFPVrbEE5Haca0DJQKjhtftOdxwvNQSngwVQOOD/5lYKn10AS0J9p0g==",
       "requires": {
-        "@colyseus/schema": "^1.0.15",
+        "@colyseus/greeting-banner": "^2.0.0",
+        "@colyseus/schema": "^2.0.4",
         "@gamestdio/timer": "^1.3.0",
         "@types/redis": "^2.8.12",
-        "debug": "^4.0.1",
+        "debug": "^4.3.4",
         "internal-ip": "^4.3.0",
-        "nanoid": "^2.0.0",
-        "notepack.io": "^2.2.0"
-      }
-    },
-    "@colyseus/loadtest": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@colyseus/loadtest/-/loadtest-0.14.4.tgz",
-      "integrity": "sha512-Y+E86INsy47vNg9X/Vyx6u7zQPzMFYGa2KkAYnTXM00L4GDrWqg40jQY4MBX0XBE3zWKm9W3+N0cgMaUZlQjKQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "^10.12.18",
-        "blessed": "^0.1.81",
-        "colyseus.js": "^0.14.8",
-        "minimist": "^1.2.0",
-        "ts-node": "^7.0.1",
-        "typescript": "^3.2.4",
-        "ws": "^6.1.4"
+        "msgpackr": "^1.9.1",
+        "nanoid": "^2.0.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-          "dev": true
-        },
-        "ts-node": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-          "dev": true,
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
-            "arrify": "^1.0.0",
-            "buffer-from": "^1.1.0",
-            "diff": "^3.1.0",
-            "make-error": "^1.1.1",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "source-map-support": "^0.5.6",
-            "yn": "^2.0.0"
-          }
-        },
-        "ws": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0"
+            "ms": "2.1.2"
           }
         }
       }
     },
-    "@colyseus/mongoose-driver": {
-      "version": "0.14.22",
-      "resolved": "https://registry.npmjs.org/@colyseus/mongoose-driver/-/mongoose-driver-0.14.22.tgz",
-      "integrity": "sha512-Bqg+1XGHo4t3UUqBxSCDuvxzuuDBObxOWVBH0GjdFmXWzJgrkMgkDFH8YXjo9h/sXaPRJNzJRlXMCV1txbYadw==",
+    "@colyseus/greeting-banner": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@colyseus/greeting-banner/-/greeting-banner-2.0.2.tgz",
+      "integrity": "sha512-BjcOIiVUyPecK5U93TIi6O0QtrejGajitH1zRqHu6ytBhzKvR40GpKLuKfsUXrUWNEY7ytKRuEQLF9akBYRqMw=="
+    },
+    "@colyseus/loadtest": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@colyseus/loadtest/-/loadtest-0.15.2.tgz",
+      "integrity": "sha512-HO+60VLgmls0NC9ALk9BPB4M+mAM/IlD30xgV+S/78mv0V9GBPI4Ycx6W6Mt3jqi8oMBAh5JbWY9Iy386A4dnQ==",
+      "dev": true,
       "requires": {
-        "@colyseus/core": "^0.14.20",
-        "mongoose": "^5.11.3"
+        "blessed": "^0.1.81",
+        "colyseus.js": "^0.15.0",
+        "minimist": "^1.2.5",
+        "typescript": ">=4.3.5",
+        "ws": "^7.4.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true
+        }
       }
     },
     "@colyseus/monitor": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/@colyseus/monitor/-/monitor-0.14.20.tgz",
-      "integrity": "sha512-D95I6f04oMOizjY24pWB3LSC7OdJFGz2K7zY8bPapLPtES+BCzPLxPI36ohAmIlMdDmsG7DRjpad77W9cUM5tg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@colyseus/monitor/-/monitor-0.15.1.tgz",
+      "integrity": "sha512-/ZT8lCjiQ82sNqmqLTUCGgaOiNeThMf8/d3srQXYg2gJqsct5xVFE9s0uFmtdObASMqs3aqQsicay/06we43Cg==",
       "requires": {
         "express": "^4.16.2",
         "node-os-utils": "^1.2.0",
         "superagent": "^3.8.2"
       }
     },
-    "@colyseus/redis-presence": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/@colyseus/redis-presence/-/redis-presence-0.14.20.tgz",
-      "integrity": "sha512-ZxpY9ji/tGYT4ms/4q5w7tjUfqekCDnpZ8J+XuXVpZN02iD6cd/RpCwIyaEsRUVpkcRZw9jxX8hSQ3L5aG/3VA==",
+    "@colyseus/redis-driver": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@colyseus/redis-driver/-/redis-driver-0.15.3.tgz",
+      "integrity": "sha512-mvOxgLpx1Nrb9hmxuMHRAKJ2MkE/37KHPYWxARKIq0/lxyO1IeZOWnszbJbd8iWN9RBsQgB6jvhrTjr08tFs/w==",
       "requires": {
-        "@colyseus/core": "^0.14.20",
-        "redis": "^2.8.0"
+        "@colyseus/core": "^0.15.0",
+        "ioredis": "^5.3.2"
+      }
+    },
+    "@colyseus/redis-presence": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@colyseus/redis-presence/-/redis-presence-0.15.2.tgz",
+      "integrity": "sha512-uq52c+fmJCNdBrbVtulhAKEa2tEiLB6y4V7ZOBC7A1ddT2Gz8JUQpCN7dvA1nmQQhiK22xe7RdGF6PDtJeL5Hw==",
+      "requires": {
+        "@colyseus/core": "^0.15.0",
+        "ioredis": "^5.3.2"
       }
     },
     "@colyseus/schema": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/@colyseus/schema/-/schema-1.0.26.tgz",
-      "integrity": "sha512-YbTTO3L7lcpxK0Bw64AwU9l0bJwaobzVn/PQQ+nc3uqZvusw7V0HBNfcAYHXc5TcDp4BuZ6c0fIttj1bx9IuGQ=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@colyseus/schema/-/schema-2.0.14.tgz",
+      "integrity": "sha512-ugbvrAxbdTufMS2TVjCpPRAx7enb+gv4CbcsszAgymaYzonlYUd+J8TYPzhIqOyRS7c41KZADToq1tMTQq3GFw=="
     },
     "@colyseus/testing": {
-      "version": "0.14.21",
-      "resolved": "https://registry.npmjs.org/@colyseus/testing/-/testing-0.14.21.tgz",
-      "integrity": "sha512-E38baXs5ljmSt4pfGi+hg5LXzez+x50M5qZAiXSWFpXs0cItKEJHGMlI2tdt7kQJIEAHkqorz+iNcJovg5pdMg==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@colyseus/testing/-/testing-0.15.2.tgz",
+      "integrity": "sha512-lL7a7ziGvuRwvdh08tHer8ciJ2VcB9doNX0YCaLrxQDsRa2XkP86+Gk709lyh7GsxIQyAnKoNr18FmFGLoI4Eg==",
       "dev": true,
       "requires": {
-        "@colyseus/arena": "^0.14.17",
-        "@colyseus/core": "^0.14.17",
-        "colyseus.js": "^0.14.13",
+        "@colyseus/core": "^0.15.0",
+        "@colyseus/tools": "^0.15.0",
+        "colyseus.js": "^0.15.0",
         "httpie": "^2.0.0-next.13"
       }
     },
-    "@colyseus/ws-transport": {
-      "version": "0.14.21",
-      "resolved": "https://registry.npmjs.org/@colyseus/ws-transport/-/ws-transport-0.14.21.tgz",
-      "integrity": "sha512-lQXqwp5MOAdFLOn6UCuSZh0hqFMRYjAkW0B0qCNqKjaGjhsupF+z6hdEX5erJpLmdMiL4wxipvYaYoG2KjxfwA==",
+    "@colyseus/tools": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@colyseus/tools/-/tools-0.15.18.tgz",
+      "integrity": "sha512-tgDA11Zx/slfl+UMPGn5q28/aQ8Nw461M1O2obgAxc/bb/iw6TxTSdbSHBpNpI2CEt/AKVLbL7XtEGBCUvxQJQ==",
       "requires": {
-        "@colyseus/core": "^0.14.20",
-        "@colyseus/schema": "^1.0.15",
+        "@colyseus/core": "^0.15.0",
+        "@colyseus/ws-transport": "^0.15.0",
+        "cors": "^2.8.5",
+        "dotenv": "^8.2.0",
+        "express": "^4.16.2",
+        "node-os-utils": "^1.3.7"
+      }
+    },
+    "@colyseus/ws-transport": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@colyseus/ws-transport/-/ws-transport-0.15.1.tgz",
+      "integrity": "sha512-9QWb0OeZHDF2+PVIJ9LY0GriItnOatJCgmAG31ygfeEn1+ApkG1Ds/+cU7aBnYE2SGGWF4sKGAM3XUvScCRq4w==",
+      "requires": {
+        "@colyseus/core": "^0.15.0",
         "@types/ws": "^7.4.4",
         "ws": "^7.4.5"
       }
@@ -9040,7 +8923,7 @@
     "@gamestdio/clock": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@gamestdio/clock/-/clock-1.1.9.tgz",
-      "integrity": "sha1-d+wMAROR+7/ctPMhEkKVNv2GgMs="
+      "integrity": "sha512-O+PG3aRRytgX2BhAPMIhbM2ftq1Q8G4xUrYjEWYM6EmpoKn8oY4lXENGhpgfww6mQxHPbjfWyIAR6Xj3y1+avw=="
     },
     "@gamestdio/timer": {
       "version": "1.3.2",
@@ -9066,6 +8949,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
+    },
+    "@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -9497,6 +9385,42 @@
         "lodash.isequal": "^4.5.0"
       }
     },
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+      "optional": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -9639,14 +9563,6 @@
         "@types/node": "*"
       }
     },
-    "@types/bson": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/chai": {
       "version": "4.2.21",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
@@ -9756,15 +9672,6 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
-    "@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz",
@@ -9812,9 +9719,9 @@
       "dev": true
     },
     "@types/redis": {
-      "version": "2.8.31",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.31.tgz",
-      "integrity": "sha512-daWrrTDYaa5iSDFbgzZ9gOOzyp2AJmYK59OlG/2KGBgYWF3lfs8GDKm1c//tik5Uc93hDD36O+qLPvzDolChbA==",
+      "version": "2.8.32",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
+      "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
       "requires": {
         "@types/node": "*"
       }
@@ -10118,12 +10025,6 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -10134,12 +10035,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
     "asynckit": {
@@ -10228,25 +10123,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "blessed": {
       "version": "0.1.81",
       "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
       "integrity": "sha1-+WLWh+wsNpVwrnGvhDJW5tDKESk=",
       "dev": true
-    },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "body-parser": {
       "version": "1.19.2",
@@ -10329,11 +10210,6 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
-    },
-    "bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -10457,6 +10333,11 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -10483,27 +10364,35 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colyseus": {
-      "version": "0.14.23",
-      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.14.23.tgz",
-      "integrity": "sha512-y2F0vmOx+k8nG2KGcKMeDNjamYNYA+x+E0dVqqWw7lD6g2PhuX8/hkGRrWagJqbFiYTIMfZfa+zN9DinAMCshg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.15.7.tgz",
+      "integrity": "sha512-ot3b/dDrox3GO1h+cAFis0S86EVrqp+GwF2ovP5yQARVhnEE89xtJPZ/DltzLzZrhCIc0XhkP35oh2SSu+d85Q==",
       "requires": {
-        "@colyseus/core": "^0.14.20",
-        "@colyseus/mongoose-driver": "^0.14.21",
-        "@colyseus/redis-presence": "^0.14.20",
-        "@colyseus/ws-transport": "^0.14.21"
+        "@colyseus/core": "^0.15.6",
+        "@colyseus/redis-driver": "^0.15.3",
+        "@colyseus/redis-presence": "^0.15.2",
+        "@colyseus/ws-transport": "^0.15.1"
       }
     },
     "colyseus.js": {
-      "version": "0.14.13",
-      "resolved": "https://registry.npmjs.org/colyseus.js/-/colyseus.js-0.14.13.tgz",
-      "integrity": "sha512-2z1jgOfozQ02gLG5RtTHpk9VZur2b7U4KI9NNldjOZmfc2DZeKejdcKchBTwiDcSwwJQQ4SSOfVUhOcBMILDqA==",
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/colyseus.js/-/colyseus.js-0.15.13.tgz",
+      "integrity": "sha512-MG6S3Zt0SZtALRKoeF/wfvkobMvHrNldJsbtrz+QQ4GSGzE+IdAx/RxkzzT5+GIqAq2W1dYyAjex/OS49bTV8g==",
       "dev": true,
       "requires": {
-        "@colyseus/schema": "^1.0.22",
+        "@colyseus/schema": "^2.0.4",
         "httpie": "^2.0.0-next.13",
-        "nanoevents": "^5.1.12",
-        "notepack.io": "^2.1.3",
-        "tslib": "^2.1.0"
+        "tslib": "^2.1.0",
+        "ws": "^8.13.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.13.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "dev": true,
+          "requires": {}
+        }
       }
     },
     "combined-stream": {
@@ -10742,9 +10631,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -10841,12 +10730,6 @@
         }
       }
     },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
-    },
     "diff-sequences": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -10892,11 +10775,6 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
       "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
-    },
-    "double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "dynamic-dedupe": {
       "version": "0.3.0",
@@ -11783,10 +11661,36 @@
         "ipaddr.js": "^1.9.0"
       }
     },
+    "ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "requires": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -11859,7 +11763,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -12792,11 +12696,6 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
     },
-    "kareem": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
-    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -12846,10 +12745,20 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -12922,12 +12831,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
     },
-    "memory-pager": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
-    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -12995,15 +12898,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
     },
     "mocha": {
       "version": "9.2.2",
@@ -13081,105 +12975,33 @@
         }
       }
     },
-    "mongodb": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.4.tgz",
-      "integrity": "sha512-K5q8aBqEXMwWdVNh94UQTwZ6BejVbFhh1uB6c5FKtPE9eUMZPUO3sRZdgIEcHSrAWmxzpG/FeODDKL388sqRmw==",
-      "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
-      },
-      "dependencies": {
-        "optional-require": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-          "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-          "requires": {
-            "require-at": "^1.0.6"
-          }
-        }
-      }
-    },
-    "mongoose": {
-      "version": "5.13.20",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.20.tgz",
-      "integrity": "sha512-TjGFa/XnJYt+wLmn8y9ssjyO2OhBMeEBtOHb9iJM16EWu2Du6L1Q6zSiEK2ziyYQM8agb4tumNIQFzqbxId7MA==",
-      "requires": {
-        "@types/bson": "1.x || 4.0.x",
-        "@types/mongodb": "^3.5.27",
-        "bson": "^1.1.4",
-        "kareem": "2.3.2",
-        "mongodb": "3.7.4",
-        "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.8.4",
-        "mquery": "3.2.5",
-        "ms": "2.1.2",
-        "optional-require": "1.0.x",
-        "regexp-clone": "1.0.0",
-        "safe-buffer": "5.2.1",
-        "sift": "13.5.2",
-        "sliced": "1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
-      }
-    },
-    "mongoose-legacy-pluralize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
-      "requires": {}
-    },
-    "mpath": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
-    },
-    "mquery": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
-      "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
-      "requires": {
-        "bluebird": "3.5.1",
-        "debug": "3.1.0",
-        "regexp-clone": "^1.0.0",
-        "safe-buffer": "5.1.2",
-        "sliced": "1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "nanoevents": {
-      "version": "5.1.13",
-      "resolved": "https://registry.npmjs.org/nanoevents/-/nanoevents-5.1.13.tgz",
-      "integrity": "sha512-JFAeG9fp0QZnRoESHjkbVFbZ9BkOXkkagUVwZVo/pkSX+Fq1VKlY+5og/8X9CYc6C7vje/CV+bwJ5M2X0+IY9Q==",
-      "dev": true
+    "msgpackr": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.7.tgz",
+      "integrity": "sha512-baUNaLvKQvVhzfWTNO07njwbZK1Lxjtb0P1JL6/EhXdLTHzR57/mZqqJC39TtQKvOmkJA4pcejS4dbk7BDgLLA==",
+      "requires": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "msgpackr-extract": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
+      "optional": true,
+      "requires": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2",
+        "node-gyp-build-optional-packages": "5.0.7"
+      }
     },
     "nanoid": {
       "version": "2.1.11",
@@ -13236,6 +13058,12 @@
         "whatwg-url": "^5.0.0"
       }
     },
+    "node-gyp-build-optional-packages": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+      "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+      "optional": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -13243,9 +13071,9 @@
       "peer": true
     },
     "node-os-utils": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/node-os-utils/-/node-os-utils-1.3.5.tgz",
-      "integrity": "sha512-bIJIlk+hA+7/ATnu3sQMtF697iw9T/JksDhKMe9uENG0OhzIG7hLM6fbcyu18bOuajlYWnSlj0IhDo2q7k0ebg=="
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/node-os-utils/-/node-os-utils-1.3.7.tgz",
+      "integrity": "sha512-fvnX9tZbR7WfCG5BAy3yO/nCLyjVWD6MghEq0z5FDfN+ZXpLWNITBdbifxQkQ25ebr16G0N7eRWJisOcMEHG3Q=="
     },
     "node-releases": {
       "version": "2.0.6",
@@ -13294,15 +13122,10 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
-    "notepack.io": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
-      "integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA=="
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -13343,11 +13166,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "optional-require": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
-    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -13365,7 +13183,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
     },
     "p-limit": {
       "version": "3.1.0",
@@ -13436,7 +13254,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -13676,41 +13494,24 @@
         "picomatch": "^2.2.1"
       }
     },
-    "redis": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
-      "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
-      }
-    },
-    "redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
     },
     "redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
-    },
-    "regexp-clone": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
     },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
-    },
-    "require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -13800,15 +13601,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "requires": {
-        "sparse-bitfield": "^3.0.3"
-      }
-    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -13893,7 +13685,7 @@
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -13901,12 +13693,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "sift": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -13963,11 +13750,6 @@
         "is-fullwidth-code-point": "^3.0.0"
       }
     },
-    "sliced": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13980,15 +13762,6 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "sparse-bitfield": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "optional": true,
-      "requires": {
-        "memory-pager": "^1.0.2"
       }
     },
     "sprintf-js": {
@@ -14012,6 +13785,11 @@
           "peer": true
         }
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "statuses": {
       "version": "1.5.0",
@@ -14062,7 +13840,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q=="
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -14357,9 +14135,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "tsutils": {
@@ -14680,12 +14458,6 @@
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
       }
-    },
-    "yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "node": "16.x"
   },
   "devDependencies": {
-    "@colyseus/loadtest": "^0.14.4",
-    "@colyseus/testing": "^0.14.21",
+    "@colyseus/loadtest": "^0.15.2",
+    "@colyseus/testing": "^0.15.2",
     "@types/chai": "^4.2.21",
     "@types/chai-as-promised": "^7.1.4",
     "@types/cors": "^2.8.6",
@@ -48,12 +48,12 @@
     "rimraf": "^2.7.1"
   },
   "dependencies": {
-    "@colyseus/arena": "^0.14.22",
-    "@colyseus/monitor": "^0.14.20",
+    "@colyseus/tools": "^0.15.2",
+    "@colyseus/monitor": "^0.15.1",
     "@mojotech/json-type-validation": "^3.1.0",
     "@types/clone": "^2.1.1",
     "clone": "^2.1.2",
-    "colyseus": "^0.14.20",
+    "colyseus": "^0.15.2",
     "cors": "^2.8.5",
     "dfg-messages": "github:yncat/dfg-messages#master",
     "dfg-simulator": "^1.3.5",

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -1,4 +1,4 @@
-import Arena from "@colyseus/arena";
+import Arena from "@colyseus/tools";
 
 /**
  * Import your Room files

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,10 @@
  * If you're self-hosting (without Arena), you can manually instantiate a
  * Colyseus Server as documented here: 👉 https://docs.colyseus.io/server/api/#constructor-options
  */
-import { listen } from "@colyseus/arena";
+import { listen } from "@colyseus/tools";
 
 // Import arena config
-import arenaConfig from "./arena.config";
+import arenaConfig from "./app.config";
 
 // Create and listen on 2567 (or PORT environment variable.)
 void listen(arenaConfig);

--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -5,8 +5,7 @@
 import sinon from "sinon";
 import { expect } from "chai";
 import { ColyseusTestServer, boot } from "@colyseus/testing";
-// import your "arena.config.ts" file here.
-import appConfig from "../src/arena.config";
+import appConfig from "../src/app.config";
 import * as dfgmsg from "dfg-messages";
 import * as dfg from "dfg-simulator";
 import { GameRoom } from "../src/rooms/game";


### PR DESCRIPTION
v0.14.24に上げてから0.15に... と思ったけど、 colyseus/test が0.14.22までしか出てなくて、型の互換性がなくてはまりました。
試しに0.15に上げてみたら普通にmigration guideに従うだけでシュッと上がったのでこれでいいやwってなりました。